### PR TITLE
v1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rysk-subgraph",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "UNLICENSED",
   "scripts": {
     "prepare:local": "mustache config/arbitrum-local.json subgraph.template.yaml > subgraph.yaml",

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -236,13 +236,17 @@ export function updateSellerPosition(
     initPositionId = initPositionId.plus(BIGINT_ONE)
     position = loadOrCreateLongPosition(seller, oToken, initPositionId, vaultId)
   }
-  position.netAmount = position.netAmount.minus(amount)
-  position.buyAmount = position.buyAmount.minus(amount)
 
-  // If the position reaches net zero:
-  // - and has a default vaultId, it is a closed naked long so we mark it as inactive.
-  // - and has a vaultId, it is being transferred to a vault as collateral so we keep it active.
-  if (position.netAmount.isZero() && vaultId == DEFAULT_VAULT_ID) position.active = false
+  // If the position is part of a naked long.
+  if (vaultId == DEFAULT_VAULT_ID) {
+    position.netAmount = position.netAmount.minus(amount)
+    position.buyAmount = position.buyAmount.minus(amount)
+
+    // If the position reaches net zero, it is user transferred so we mark it as inactive.
+    if (position.netAmount.isZero()) position.active = false
+  }
+
+  // If the position has a vaultId, it is being transferred to a vault as collateral so we keep it unchanged.
 
   let transactions = position.optionsTransferTransactions
   transactions.push(tradeId)

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -238,8 +238,11 @@ export function updateSellerPosition(
   }
   position.netAmount = position.netAmount.minus(amount)
   position.buyAmount = position.buyAmount.minus(amount)
-  // set position to inactive (closed) whenever we get back to zero longs and shorts
-  if (position.netAmount.isZero()) position.active = false
+
+  // If the position reaches net zero:
+  // - and has a default vaultId, it is a closed naked long so we mark it as inactive.
+  // - and has a vaultId, it is being transferred to a vault as collateral so we keep it active.
+  if (position.netAmount.isZero() && vaultId == DEFAULT_VAULT_ID) position.active = false
 
   let transactions = position.optionsTransferTransactions
   transactions.push(tradeId)

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -27,6 +27,8 @@ export const SHORT_OTOKEN_MINTED = '0x4d7f96086c92b2f9a254ad21548b1c1f2d99502c79
 const COLLATERAL_ASSET_DEPOSITED = '0xbfab88b861f171b7db714f00e5966131253918d55ddba816c3eb94657d102390'
 const COLLATERAL_ASSET_WITHDRAWN = '0xfe86f7694b6c54a528acbe27be61dd4a85e9a89aeef7f650a1b439045ccee5a4'
 
+export const DEFAULT_VAULT_ID = '0'
+
 export function isZeroAddress(value: Address): boolean {
   return value.toHex() == ZERO_ADDRESS
 }
@@ -179,7 +181,7 @@ export function loadLongPosition(
   user: Address,
   oToken: string,
   numId: BigInt,
-  vaultId: string = '0',
+  vaultId: string = DEFAULT_VAULT_ID,
 ): LongPosition | null {
   let id = user.toHex() + '-' + oToken + '-l-' + numId.toString() + '-' + vaultId
   let position = LongPosition.load(id)
@@ -375,7 +377,7 @@ export function updateLiquidatedPosition(
 
 export function getVaultIdFromLogs(account: Address, txLogs: ethereum.Log[]): string {
   // Check TX logs to find the presence of a vault ID or default to zero.
-  let vaultId = '0'
+  let vaultId = DEFAULT_VAULT_ID
   const logsLength = txLogs.length
 
   for (let index = 0; index < logsLength; index++) {

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -4,8 +4,8 @@ schema:
 features:
   - grafting
 graft:
-  base: QmR5uLKowVBwxevukEKShfZCfDK7kQha3HNDg2Rm2oczcy
-  block: 39893000
+  base: QmPD5445zNDu96VkgdT4TaTfLNn5CdrKimBmAub68atd4s
+  block: 44400000
 dataSources:
   - kind: ethereum
     name: liquidityPool


### PR DESCRIPTION
# Release notes
- Bump to version 1.3.1.
- Now hard coding the default `vaultId` for position IDs.
- Now only marking transferred positions as `active == false` when they are naked longs.